### PR TITLE
Feat/setup ffmpeg wasm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "mux-it",
       "version": "0.0.0",
       "dependencies": {
-        "@ffmpeg/core": "^0.12.10",
         "@ffmpeg/ffmpeg": "^0.12.15",
+        "@ffmpeg/util": "^0.12.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -637,15 +637,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@ffmpeg/core": {
-      "version": "0.12.10",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.12.10.tgz",
-      "integrity": "sha512-dzNplnn2Nxle2c2i2rrDhqcB19q9cglCkWnoMTDN9Q9l3PvdjZWd1HfSPjCNWc/p8Q3CT+Es9fWOR0UhAeYQZA==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
     "node_modules/@ffmpeg/ffmpeg": {
       "version": "0.12.15",
       "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.12.15.tgz",
@@ -665,6 +656,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/@ffmpeg/util": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/util/-/util-0.12.2.tgz",
+      "integrity": "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,14 @@
       "name": "mux-it",
       "version": "0.0.0",
       "dependencies": {
+        "@ffmpeg/core": "^0.12.10",
+        "@ffmpeg/ffmpeg": "^0.12.15",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@types/node": "^24.0.12",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react-swc": "^3.10.2",
@@ -632,6 +635,36 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@ffmpeg/core": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.12.10.tgz",
+      "integrity": "sha512-dzNplnn2Nxle2c2i2rrDhqcB19q9cglCkWnoMTDN9Q9l3PvdjZWd1HfSPjCNWc/p8Q3CT+Es9fWOR0UhAeYQZA==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/@ffmpeg/ffmpeg": {
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.12.15.tgz",
+      "integrity": "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ffmpeg/types": "^0.12.4"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
+    },
+    "node_modules/@ffmpeg/types": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/types/-/types-0.12.4.tgz",
+      "integrity": "sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1264,6 +1297,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
+      "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -2872,6 +2915,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ffmpeg/core": "^0.12.10",
+    "@ffmpeg/ffmpeg": "^0.12.15",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@types/node": "^24.0.12",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react-swc": "^3.10.2",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ffmpeg/core": "^0.12.10",
     "@ffmpeg/ffmpeg": "^0.12.15",
+    "@ffmpeg/util": "^0.12.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,15 +127,6 @@ function App() {
         </> :
         <p>Loading Ffmpeg WASM.  This may take some time...</p>
       }
-
-      {/* <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div> */}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,11 +16,11 @@ function App() {
     onProgress: (progress: number) => console.log(`Progress: ${progress}`)
   };
 
-  const { ready, loadCallback, runCallback, writeCallback, readCallback, fetchFile } = useFfmpeg(useFfmpegOptions);
+  const { ready, load, run, write, read, fetchFile } = useFfmpeg(useFfmpegOptions);
 
   useEffect(() => {
-    loadCallback();
-  }, [ loadCallback ]);
+    load();
+  }, [ load ]);
 
   const addVideos = (files: FileList | null) => {
     if (!files) {
@@ -53,7 +53,7 @@ function App() {
 
     const videoListText: string = videos.map(video => `file '${video.sanitized_temp_file_name}'`)
                                         .join("\n");
-    await writeCallback("videos.txt", new TextEncoder().encode(videoListText));
+    await write("videos.txt", new TextEncoder().encode(videoListText));
 
     // TODO: Modify the output to not force an MP4 container, as this may not match what the user has requested:
     const outputPath: string = "output.mp4";
@@ -71,17 +71,16 @@ function App() {
     // let args: string[] = [ "-i", concatArg, "-c", "copy", outputPath ];
 
     for (const video of videos) {
-      await writeCallback(video.sanitized_temp_file_name, await fetchFile(video.file));
+      await write(video.sanitized_temp_file_name, await fetchFile(video.file));
     }
 
-    // Truthy case here would be a non-zero exit code (failed):
-    const isRunSuccessful: boolean = await runCallback(args);
+    const isRunSuccessful: boolean = await run(args);
     if (!isRunSuccessful) {
       setErrorMessage("Failed to mux videos!");
       return;
     }
 
-    const outputData: FileData = await readCallback(outputPath);
+    const outputData: FileData = await read(outputPath);
 
     // Converting to unknown does feel like a code smell here, but TS is complaining and the Ffmpeg WASM documentation suggests doing this:
     const data: Uint8Array<ArrayBuffer> = new Uint8Array((outputData as unknown) as ArrayBuffer);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,7 +96,7 @@ function App() {
             onChange={ (e) => addVideos(e.target.files) }
           />
 
-          { videos && videos.length > 0 &&
+          { videos && videos.length > 1 &&
             <>
               <ul>
                 { videos.map( (video) => (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import "./css/App.css";
+import "@muxit/css/App.css";
 
 function App() {
   const [count, setCount] = useState(0)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,18 +57,7 @@ function App() {
 
     // TODO: Modify the output to not force an MP4 container, as this may not match what the user has requested:
     const outputPath: string = "output.mp4";
-    let args: string[] = [ 
-      "-f",
-      "concat",
-      "-safe",
-      "0",
-      "-i",
-      "videos.txt",
-      "-c",
-      "copy",
-      outputPath
-    ];
-    // let args: string[] = [ "-i", concatArg, "-c", "copy", outputPath ];
+    let args: string[] = [ "-f", "concat", "-safe", "0", "-i", "videos.txt", "-c", "copy", outputPath ];
 
     for (const video of videos) {
       await write(video.sanitized_temp_file_name, await fetchFile(video.file));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,132 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useFfmpeg } from "@muxit/hooks/useFfmpeg";
 import "@muxit/css/App.css";
+import type { FileData } from "@ffmpeg/ffmpeg";
 
 function App() {
-  const [count, setCount] = useState(0)
+  const { ready, log, loadCallback, runCallback, writeCallback, readCallback, fetchFile } = useFfmpeg();
+  
+  const [ errorMessage, setErrorMessage ] = useState<string>();
+  const [ videos, setVideos ] = useState<File[]>([]);
+  const [ outputBlobUrl, setOutputBlobUrl ] = useState<string>();
+
+  useEffect(() => {
+    loadCallback();
+  }, [ loadCallback ]);
+
+  const addVideos = (files: FileList | null) => {
+    if (!files) {
+      setErrorMessage("No videos were selected!");
+      return;
+    }
+
+    const existingFileNames: string[] = videos.map(video => video.name);
+    
+    for (const file of files) {
+      if (existingFileNames.includes(file.name)) {
+        continue;
+      }
+
+      setVideos([ ...videos, file ]);
+    }
+  };
+
+  const muxVideos = async () => {
+    if (!videos || videos.length === 0) {
+      setErrorMessage("No videos were selected!");
+      return;
+    }
+
+    let args: string[] = [ "-i" ];
+    let concatArg: string = "concat:";
+    let isFirst: boolean = false;
+
+    for (const video of videos) {
+      await writeCallback(video.name, await fetchFile(video));
+
+      if (!isFirst) {
+        concatArg += "|";
+      }
+      else {
+        isFirst = false;
+      }
+
+      concatArg += video.name;
+    }
+
+    // TODO: Modify the output to not force an MP4 container, as this may not match what the user has requested:
+    const outputPath: string = "output.mp4";
+    args = [ ...args, "-c", "copy", outputPath ];
+
+    await runCallback(args);
+
+    const outputData: FileData = await readCallback(outputPath);
+
+    // Converting to unknown does feel like a code smell here, but TS is complaining and the Ffmpeg WASM documentation suggests doing this:
+    const data: Uint8Array<ArrayBuffer> = new Uint8Array((outputData as unknown) as ArrayBuffer);
+    const dataBlob: Blob = new Blob([data.buffer], { type: "video/mp4" });
+    const blobUrl: string = URL.createObjectURL(dataBlob);
+
+    setOutputBlobUrl(blobUrl);
+  };
 
   return (
     <>
       <h1>MuxIt</h1>
-      <div className="card">
+
+      { errorMessage &&
+        <p>{ `Error: ${errorMessage}` }</p>
+      }
+
+      { ready ? 
+        <>
+          <h3>Add videos:</h3>
+          <input
+            type="file"
+            accept="video/*"
+            onChange={ (e) => addVideos(e.target.files) }
+          />
+
+          { videos && videos.length > 0 &&
+            <>
+              <ul>
+                { videos.map( (video) => (
+                    <li key={ video.name }>
+                      { video.name }
+                    </li>
+                  ))
+                }
+              </ul>
+              
+              <button
+                onClick={ (e) => muxVideos() }
+              >
+                Mux videos
+              </button>
+            </>
+          }
+
+          { outputBlobUrl &&
+            <>
+              <h3>Output video:</h3>
+              <video 
+                src="{ outputBlobUrl }"
+                controls
+              />
+            </>
+          }
+        </> :
+        <p>Loading Ffmpeg WASM.  This may take some time...</p>
+      }
+
+      {/* <div className="card">
         <button onClick={() => setCount((count) => count + 1)}>
           count is {count}
         </button>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
-      </div>
+      </div> */}
     </>
   );
 }

--- a/src/hooks/useFfmpeg.ts
+++ b/src/hooks/useFfmpeg.ts
@@ -1,5 +1,5 @@
 import { useRef, useState, useCallback } from "react";
-import { FFmpeg, type FFMessageLoadConfig } from "@ffmpeg/ffmpeg";
+import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { fetchFile } from "@ffmpeg/util";
 import type { UseFfmpegOptions } from "@muxit/models/useFfmpegOptions";
 
@@ -18,9 +18,10 @@ export function useFfmpeg(options: UseFfmpegOptions) {
     }
 
     ffmpegRef.current!.on("log", ({ message }) => options.onLog(message));
-    ffmpegRef.current!.on("progress", ({ progress }) => options.onProgress(progress));
+    ffmpegRef.current!.on("progress", (progress) => options.onProgress(progress.progress));
 
-    await ffmpegRef.current!.load(undefined); // Accepts FFMessageLoadConfig, though I have no current need for this.
+    // The 'load' method accepts FFMessageLoadConfig, though I have no current need for this:
+    await ffmpegRef.current!.load(undefined);
 
     setReady(true);
   }, [ ready, options ]);
@@ -37,9 +38,7 @@ export function useFfmpeg(options: UseFfmpegOptions) {
 
     const exitCode: number = await ffmpegRef.current!.exec(args);
 
-    // Success exit code would be 0, so we can invert the truthy/falsy check to check if the run was successful:
-    console.log(exitCode);
-    console.log(`Success? ${!Boolean(exitCode)}`)
+    // Success exit code would be 0, so I want to invert the truthy/falsy check to check if the run was successful:
     const isSuccessful: boolean = !Boolean(exitCode);
     return isSuccessful;
   }, [ ready ]);

--- a/src/hooks/useFfmpeg.ts
+++ b/src/hooks/useFfmpeg.ts
@@ -1,0 +1,46 @@
+import { useRef, useState, useCallback } from "react";
+import { FFmpeg, type FFMessageLoadConfig } from "@ffmpeg/ffmpeg";
+import { fetchFile } from "@ffmpeg/util";
+
+export function useFfmpeg(options?: FFMessageLoadConfig) {
+  const ffmpegRef = useRef<FFmpeg | null>(null);
+
+  const [ ready, setReady ] = useState<boolean>(false);
+  const [ log, setLog ] = useState<string>("");
+
+  if (!ffmpegRef.current) {
+    ffmpegRef.current = new FFmpeg();
+  }
+
+  const loadCallback = useCallback(async () => {
+    if (ready) {
+      return;
+    }
+
+    ffmpegRef.current!.on("log", ({ message }) => setLog(message));
+    await ffmpegRef.current!.load(options);
+
+    setReady(true);
+  }, [ ready, options ]);
+
+
+  const runCallback = useCallback((args: string[]) => {
+    if (!ready) {
+        setLog("Cannot execute Ffmpeg command, as it's not ready");
+        return;
+    }
+
+    return ffmpegRef.current!.exec(args);
+  }, [ ready ]);
+
+  const writeCallback = useCallback(async (name: string, data: Uint8Array | ArrayBuffer) =>{
+    const currentData = data instanceof Uint8Array ? data : new Uint8Array(data);
+    await ffmpegRef.current!.writeFile(name, currentData);
+  }, []);
+
+  const readCallback = useCallback((name: string) => {
+    return ffmpegRef.current!.readFile(name);
+  }, []);
+
+  return { ready, log, loadCallback, runCallback, writeCallback, readCallback, fetchFile };
+}

--- a/src/hooks/useFfmpeg.ts
+++ b/src/hooks/useFfmpeg.ts
@@ -12,7 +12,7 @@ export function useFfmpeg(options: UseFfmpegOptions) {
     ffmpegRef.current = new FFmpeg();
   }
 
-  const loadCallback = useCallback(async () => {
+  const load = useCallback(async () => {
     if (ready) {
       return;
     }
@@ -26,7 +26,7 @@ export function useFfmpeg(options: UseFfmpegOptions) {
   }, [ ready, options ]);
 
 
-  const runCallback = useCallback(async (args: string[]): Promise<boolean> => {
+  const run = useCallback(async (args: string[]): Promise<boolean> => {
     if (!ready) {
       options.onError("Cannot execute Ffmpeg command, as it's not ready");
       return false;
@@ -44,14 +44,14 @@ export function useFfmpeg(options: UseFfmpegOptions) {
     return isSuccessful;
   }, [ ready ]);
 
-  const writeCallback = useCallback(async (name: string, data: Uint8Array | ArrayBuffer) =>{
+  const write = useCallback(async (name: string, data: Uint8Array | ArrayBuffer) =>{
     const currentData = data instanceof Uint8Array ? data : new Uint8Array(data);
     await ffmpegRef.current!.writeFile(name, currentData);
   }, []);
 
-  const readCallback = useCallback((name: string) => {
+  const read = useCallback((name: string) => {
     return ffmpegRef.current!.readFile(name);
   }, []);
 
-  return { ready, loadCallback, runCallback, writeCallback, readCallback, fetchFile };
+  return { ready, load, run, write, read, fetchFile };
 }

--- a/src/hooks/useFfmpeg.ts
+++ b/src/hooks/useFfmpeg.ts
@@ -36,7 +36,12 @@ export function useFfmpeg(options: UseFfmpegOptions) {
     options.onLog(`Executing the following Ffmpeg WASM command: '${argsString}'`);
 
     const exitCode: number = await ffmpegRef.current!.exec(args);
-    return !exitCode;
+
+    // Success exit code would be 0, so we can invert the truthy/falsy check to check if the run was successful:
+    console.log(exitCode);
+    console.log(`Success? ${!Boolean(exitCode)}`)
+    const isSuccessful: boolean = !Boolean(exitCode);
+    return isSuccessful;
   }, [ ready ]);
 
   const writeCallback = useCallback(async (name: string, data: Uint8Array | ArrayBuffer) =>{

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "./css/index.css";
-import App from "./App.tsx";
+import "@muxit/css/index.css";
+import App from "@muxit/App.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/models/useFfmpegOptions.ts
+++ b/src/models/useFfmpegOptions.ts
@@ -1,0 +1,5 @@
+export type UseFfmpegOptions = {
+  onLog: (message: string) => void;
+  onError: (message: string) => void;
+  onProgress: (progress: number) => void;
+};

--- a/src/models/video.ts
+++ b/src/models/video.ts
@@ -1,0 +1,4 @@
+export type Video = {
+  file: File;
+  sanitized_temp_file_name: string;
+};

--- a/tsconfig.aliases.json
+++ b/tsconfig.aliases.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@muxit/*": ["src/*"]
+    }
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.aliases.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.aliases.json" }
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.aliases.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,5 +9,13 @@ export default defineConfig({
     alias: {
       "@muxit": path.resolve(__dirname, "src")
     }
+  },
+  optimizeDeps: {
+    exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
+  },
+  build: {
+    rollupOptions: {
+      external: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
+    }
   }
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@muxit": path.resolve(__dirname, "src")
+    }
+  }
 });


### PR DESCRIPTION
Initial implementation of Ffmpeg WASM logic within a basic React app:
- Update package dependencies.
- Add page content for addVideos, muxVideos, utilise Ffmpeg within WASM and useFfmpeg hook.
- Add muxit import aliases.