### PR TITLE
fix: Resolve base path issue with GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Build Site
         run: npm run build
+        env:
+          VITE_BASE_PATH: "/MuxIt/"
 
       - name: Publish Site Artifact
         uses: actions/upload-artifact@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
+  // After researching this, if this isn't added then the JS/CSS default to /index.css instead of /muxit/index.css
+  // I currently need this for GitHub Pages, but using environment variables here allows it to be configured differently if needed, in future.
+  base: process.env.VITE_BASE_PATH ?? "/",
+
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
An attempt to resolve issues where the CSS and JS files wouldn't load as these were expecting:
https://harrycmather.github.io/index.css instead of https://harrycmather.github.io/MuxIt/index.css
This appears to be resolvable by setting "base" within the vite config.  I've made this configurable by setting it to an environment variable, meaning any changes in-future, ie: switching to Apache/IIS would not require significant changes to adopt this (would just require a different environment variable).