### PR TITLE
Feat/styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ A client-side website for combining multiple video clips together using React wi
  - Add CI/CD using GitHub actions and Releases.
  - Create Docker setup.
  - Add features for re-ordering clips before muxing.
+
+ - Look into results in Google Lighthouse
+ - See how to show an error to unsupported browsers

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "mux-it",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
         "react": "^19.1.0",
@@ -26,6 +29,73 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.35.1",
         "vite": "^7.0.4"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2865,6 +2935,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
     "react": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import "@muxit/css/App.css";
 import type { FileData } from "@ffmpeg/ffmpeg";
 import type { UseFfmpegOptions } from "@muxit/models/useFfmpegOptions";
 import type { Video } from "@muxit/models/video";
+import Timeline from "./components/Timeline";
 
 function App() {
   const [ errorMessage, setErrorMessage ] = useState<string>();
@@ -87,7 +88,7 @@ function App() {
         <p>{ `Error: ${errorMessage}` }</p>
       }
 
-      { ready ? 
+      { ready ?
         <>
           <h3>Add videos:</h3>
           <input
@@ -96,23 +97,24 @@ function App() {
             onChange={ (e) => addVideos(e.target.files) }
           />
 
-          { videos && videos.length > 1 &&
-            <>
-              <ul>
-                { videos.map( (video) => (
-                    <li key={ video.file.name }>
-                      { video.file.name }
-                    </li>
-                  ))
+          { videos && videos.length > 0 && (
+              <>
+                <h3>Timeline (drag to re-order clips):</h3>
+                <Timeline
+                  videos={ videos }
+                  onReorder={ (newOrder) => setVideos(newOrder) }
+                />
+
+                { videos.length > 1 && (
+                    <button 
+                      onClick={ (_) => muxVideos() }
+                    >
+                      Mux videos
+                    </button>
+                  )
                 }
-              </ul>
-              
-              <button
-                onClick={ (_) => muxVideos() }
-              >
-                Mux videos
-              </button>
-            </>
+              </>
+            )
           }
 
           { outputBlobUrl &&

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,16 +33,20 @@ function App() {
 
     // I would much prefer to use a .filter followed by .map here, as this would be cleaner.  Sadly, FileLists don't support this.
     const newVideos: Video[] = [];
+    let count: number = videos.length;
     for (const file of files) {
       if (existingFileNames.includes(file.name)) {
         continue;
       }
 
       newVideos.push({
-        sanitized_temp_file_name: `${videos.length}.mp4`, // TODO: Better handle different file extensions.
+        sanitized_temp_file_name: `${count}.mp4`, // TODO: Better handle different file extensions.
         file: file
       });
+
+      count++;
     }
+
     setVideos((previous) => [ ...previous, ...newVideos ]);
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,20 +30,20 @@ function App() {
     }
 
     const existingFileNames: string[] = videos.map(video => video.file.name);
-    
-    // TODO : Verify which scenarios actually allow multiple files to be selected.
-    // If multiple files are never selected, the foreach is redundant.
+
+    // I would much prefer to use a .filter followed by .map here, as this would be cleaner.  Sadly, FileLists don't support this.
+    const newVideos: Video[] = [];
     for (const file of files) {
       if (existingFileNames.includes(file.name)) {
         continue;
       }
 
-      const video: Video = {
+      newVideos.push({
         sanitized_temp_file_name: `${videos.length}.mp4`, // TODO: Better handle different file extensions.
         file: file
-      };
-      setVideos([ ...videos, video ]);
+      });
     }
+    setVideos((previous) => [ ...previous, ...newVideos ]);
   };
 
   const muxVideos = async () => {
@@ -94,6 +94,7 @@ function App() {
           <input
             type="file"
             accept="video/*"
+            multiple
             onChange={ (e) => addVideos(e.target.files) }
           />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,7 @@ function App() {
             onChange={ (e) => addVideos(e.target.files) }
           />
 
-          { videos && videos.length > 0 && (
+          { videos && videos.length > 1 && (
               <>
                 <h3>Timeline (drag to re-order clips):</h3>
                 <Timeline
@@ -105,14 +105,11 @@ function App() {
                   onReorder={ (newOrder) => setVideos(newOrder) }
                 />
 
-                { videos.length > 1 && (
-                    <button 
-                      onClick={ (_) => muxVideos() }
-                    >
-                      Mux videos
-                    </button>
-                  )
-                }
+                <button 
+                  onClick={ (_) => muxVideos() }
+                >
+                  Mux videos
+                </button>
               </>
             )
           }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from "react";
 import { useFfmpeg } from "@muxit/hooks/useFfmpeg";
 import "@muxit/css/App.css";
-import type { FileData } from "@ffmpeg/ffmpeg";
 import type { UseFfmpegOptions } from "@muxit/models/useFfmpegOptions";
 import type { Video } from "@muxit/models/video";
-import Timeline from "./components/Timeline";
+import Timeline from "@muxit/components/Timeline";
 
 function App() {
   const [ errorMessage, setErrorMessage ] = useState<string>();
@@ -74,10 +73,7 @@ function App() {
       return;
     }
 
-    const outputData: FileData = await read(outputPath);
-
-    // Converting to unknown does feel like a code smell here, but TS is complaining and the Ffmpeg WASM documentation suggests doing this:
-    const data: Uint8Array<ArrayBuffer> = new Uint8Array((outputData as unknown) as ArrayBuffer);
+    const data: Uint8Array<ArrayBuffer> = await read(outputPath);
     const dataBlob: Blob = new Blob([data.buffer], { type: "video/mp4" });
     const blobUrl: string = URL.createObjectURL(dataBlob);
 

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,0 +1,9 @@
+import "@muxit/css/Timeline.css";
+import type { TimelineProps } from "@muxit/models/timelineProps";
+import type { Video } from "@muxit/models/video";
+import TimelineClip from "@muxit/components/TimelineClip";
+
+function Timeline({ videos, onReorder }: TimelineProps) {
+}
+
+export default Timeline;

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,9 +1,60 @@
 import "@muxit/css/Timeline.css";
+import { SortableContext, arrayMove, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { DndContext, PointerSensor, closestCenter, useSensor, useSensors } from "@dnd-kit/core";
+import type { DragEndEvent, SensorDescriptor, SensorOptions } from "@dnd-kit/core";
 import type { TimelineProps } from "@muxit/models/timelineProps";
 import type { Video } from "@muxit/models/video";
 import TimelineClip from "@muxit/components/TimelineClip";
 
 function Timeline({ videos, onReorder }: TimelineProps) {
+  const mouseSensor = useSensor(PointerSensor, {
+    activationConstraint: { 
+      distance: 5
+    }
+  });
+
+  const sensors: SensorDescriptor<SensorOptions>[] = useSensors(mouseSensor);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    // Some context for this:
+    //  - Over refers to the item that dragged item has been dropped on-top of.
+    //  - Active refers to the item that is being dragged.
+    const { active, over } = event;
+    if (!over || over.id === active.id) {
+      return;
+    }
+
+    // TODO: Test the memory footprint here, since arrayMove is a pure function and doesn't mutate the existing array:
+    const oldIndex: number = videos.findIndex((video) => video.file.name === active.id);
+    const newIndex: number = videos.findIndex((video) => video.file.name === over.id);
+    const newOrder: Video[] = arrayMove(videos, oldIndex, newIndex);
+
+    onReorder(newOrder);
+  };
+
+  return (
+    <DndContext
+      sensors={ sensors }
+      collisionDetection={ closestCenter }
+      onDragEnd={ handleDragEnd }
+    >
+      <SortableContext
+        items={ videos.map((video) => video.file.name) }
+        strategy={ verticalListSortingStrategy }
+      >
+        <div className="timeline">
+          { videos.map( (video) => (
+              <TimelineClip
+                key={ video.file.name }
+                id={ video.file.name }
+                name={ video.file.name }
+              />
+            ))
+          }
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
 }
 
 export default Timeline;

--- a/src/components/TimelineClip.tsx
+++ b/src/components/TimelineClip.tsx
@@ -1,8 +1,25 @@
 import "@muxit/css/TimelineClip.css";
+import { CSS } from "@dnd-kit/utilities";
+import { useSortable } from "@dnd-kit/sortable";
 
 function TimelineClip({ id, name }: { id: string; name: string }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition: transition
+  };
 
   return (
+    <div
+      ref={ setNodeRef }
+      className="timeline-item"
+      style={ style }
+      { ...attributes }
+      { ...listeners }
+    >
+      { name }
+    </div>
   );
 }
 

--- a/src/components/TimelineClip.tsx
+++ b/src/components/TimelineClip.tsx
@@ -1,0 +1,9 @@
+import "@muxit/css/TimelineClip.css";
+
+function TimelineClip({ id, name }: { id: string; name: string }) {
+
+  return (
+  );
+}
+
+export default TimelineClip;

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -1,42 +1,6 @@
 #root {
-  max-width: 1280px;
+  max-width: 100%;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -4,3 +4,12 @@
   padding: 2rem;
   text-align: center;
 }
+
+video {
+  width: 50%;
+  height: 50%;
+  border: 1.25px solid #646cff;
+  gap: 0.5rem;
+  padding: 0.1rem;
+  border-radius: 6px;
+}

--- a/src/css/Timeline.css
+++ b/src/css/Timeline.css
@@ -1,5 +1,6 @@
 .timeline {
   display: flex;
+  flex-direction: column;
   gap: 0.5rem;
   padding: 0.5rem;
   overflow-x: auto;

--- a/src/css/Timeline.css
+++ b/src/css/Timeline.css
@@ -1,0 +1,10 @@
+.timeline {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  overflow-x: auto;
+  border: 1px solid #555;
+  border-radius: 8px;
+  margin: 1rem 0;
+  justify-content: center;
+}

--- a/src/css/Timeline.css
+++ b/src/css/Timeline.css
@@ -4,8 +4,8 @@
   gap: 0.5rem;
   padding: 0.5rem;
   overflow-x: auto;
-  border: 1px solid #555;
-  border-radius: 8px;
+  border: 1px solid #646cff;
+  border-radius: 6px;
   margin: 1rem 0;
   justify-content: center;
 }

--- a/src/css/TimelineClip.css
+++ b/src/css/TimelineClip.css
@@ -1,0 +1,9 @@
+.timeline-item {
+  background: #333;
+  border: 1px solid #555;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  white-space: nowrap;
+  cursor: grab;
+  user-select: none;
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -31,8 +31,8 @@ body {
 }
 
 h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  margin-top: 0;
+  font-size: 2.5rem;
 }
 
 button {

--- a/src/hooks/useFfmpeg.ts
+++ b/src/hooks/useFfmpeg.ts
@@ -48,8 +48,12 @@ export function useFfmpeg(options: UseFfmpegOptions) {
     await ffmpegRef.current!.writeFile(name, currentData);
   }, []);
 
-  const read = useCallback((name: string) => {
-    return ffmpegRef.current!.readFile(name);
+  const read = useCallback(async (name: string) => {
+    const fileData = await ffmpegRef.current!.readFile(name);
+
+    // Converting to unknown does feel like a code smell here, but TS is complaining and the Ffmpeg WASM documentation suggests doing this:
+    const data: Uint8Array<ArrayBuffer> = new Uint8Array((fileData as unknown) as ArrayBuffer);
+    return data;
   }, []);
 
   return { ready, load, run, write, read, fetchFile };

--- a/src/models/timelineProps.ts
+++ b/src/models/timelineProps.ts
@@ -1,0 +1,6 @@
+import type { Video } from "@muxit/models/video";
+
+export type TimelineProps = {
+  videos: Video[];
+  onReorder: (newOrder: Video[]) => void;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,5 +13,13 @@ export default defineConfig({
     alias: {
       "@muxit": path.resolve(__dirname, "src")
     }
-  }
+  },
+  // optimizeDeps: {
+  //   exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
+  // },
+  // build: {
+  //   rollupOptions: {
+  //     external: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
+  //   }
+  // }
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,13 +13,5 @@ export default defineConfig({
     alias: {
       "@muxit": path.resolve(__dirname, "src")
     }
-  },
-  // optimizeDeps: {
-  //   exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
-  // },
-  // build: {
-  //   rollupOptions: {
-  //     external: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
-  //   }
-  // }
+  }
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,13 +16,13 @@ export default defineConfig({
   },
 
   // These two JSON sections are required when running "npm run dev" locally, but cannot be included in the release builds:
-  optimizeDeps: {
-    exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
-  },
-  build: {
-    rollupOptions: {
-      external: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
-    }
-  }
-  
+  // optimizeDeps: {
+  //   exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
+  // },
+  // build: {
+  //   rollupOptions: {
+  //     external: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
+  //   }
+  // }
+
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,5 +13,16 @@ export default defineConfig({
     alias: {
       "@muxit": path.resolve(__dirname, "src")
     }
+  },
+
+  // These two JSON sections are required when running "npm run dev" locally, but cannot be included in the release builds:
+  optimizeDeps: {
+    exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
+  },
+  build: {
+    rollupOptions: {
+      external: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
+    }
   }
+  
 });


### PR DESCRIPTION
An initial and temporary implementation of some potential styling options for the site.  This will be improved further in-future.
This branch contains the following changes:
 - Updated readme.
 - Set a max width/height to prevent the output video from exceeding the width/height dimensions.
 - Added dnd-kit packages for re-ordering clips before starting to "mux".
 - Moved the final remaining ffmpeg package reference within App.tsx (from the read call) to be contained within the useFfmpeg hook.
 - Added element within Video selector to allow multiple videos to be selected simultaneously when "selecting files".
 - Fixed a bug where subsequent calls to setVideos without utilizing the previous value would result in the value not being updated (race condition due to how useState works).
 - Fixed a bug where selecting multiple videos at once would result in one of the clips being duplicated in the output recording.
 - Split Timeline and TimelineClip into their own components.
 - Removed some leftover CSS from the sample React + Vite project.